### PR TITLE
New Feature: PCI config space logging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,10 @@ edition = "2021"
 [dependencies]
 # implicitly defines a feature like "dep:log"
 log = { version = "0.4.14", default-features = false, optional = true }
+arrayvec = "*"
+
+[features]
+default = ["log"]
+
+[dev-dependencies]
+env_logger = "0.9"


### PR DESCRIPTION
- struct Device impl print_pci_config_space which log!() its hexadecimal dump of the standard part of the configuration space (the first 64 bytes).