### PR TITLE
Bug FIx: PCI logging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 [dependencies]
 # implicitly defines a feature like "dep:log"
 log = { version = "0.4.14", default-features = false, optional = true }
-arrayvec = "*"
+arrayvec = {version = "*", default-features = false}
 
 [features]
 default = ["log"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1074,7 +1074,7 @@ impl Device {
     }
 
     fn print_config_space_bytes(&self, num_bytes: usize) {
-        const BUFFER_SIZE: usize = 100;
+        const BUFFER_SIZE: usize = 70;
         let mut buf = ArrayString::<BUFFER_SIZE>::new();
 
         log::info!(target: "",


### PR DESCRIPTION
- arrayvec uses sdt (not checked by #![cfg_attr(not(test), no_std)])
- re-implemented logging wihout arrayvec

Bug=[SW-8085]